### PR TITLE
Switch to Giscus and link fixes

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,11 +18,9 @@ website:
     site: "@theRcast"
     card-style: summary_large_image
   comments:
-    utterances:
+    giscus: 
       repo: shinydevseries/shinydevseries_site
-      label: utterances
-      theme: body-light
-      issue-term: title
+      mapping: title
     
   navbar:
     logo: assets/img/shinydevseries_hex.png

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -28,7 +28,7 @@ website:
     logo: assets/img/shinydevseries_hex.png
     tools:
     - icon: github
-      href: https://github.com/shinydevseries/site_rewrite_quarto
+      href: https://github.com/shinydevseries/shinydevseries_site
     
     right:
       - text: Interviews


### PR DESCRIPTION
This PR pivots the commenting engine to Giscus per advice from the community, as well as fixes the link to the site's GitHub repository in the navigation bar.